### PR TITLE
Fix package install issue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,8 @@ Imports:
     magrittr,
     terra,
     tidyterra
-Remotes: afsc-gap-products/akgfmaps
+Remotes: 
+  akgfmaps=afsc-gap-products/akgfmaps
 Depends: 
     R (>= 3.5.0)
 LazyData: 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,10 @@ Authors:
 # Installation
 `EFHSDM` can be installed using the following code:
 ```r
-devtools::install_github("afsc-gap-products/akgfmaps", build_vignettes=TRUE)
-devtools::install_github("alaska-groundfish-efh/EFHSDM@main", dependencies = TRUE, build_vignettes = FALSE)
+pak::pak("alaska-groundfish-efh/EFHSDM@main")
 
 # Development version - not currently recommended unless you are an active developer
-# devtools::install_github("alaska-groundfish-efh/EFHSDM@dev", dependencies = TRUE, build_vignettes = FALSE)
+# pak::pak("alaska-groundfish-efh/EFHSDM@dev")
 ```
 
 


### PR DESCRIPTION
## Justification

The EFHSDM package will not install since the reference to the dependency `akgfmaps` in the DESCRIPTION file is incomplete. In addition, the  `devtools` package is having problems resolving the install. A switch to the R package `pak` for installing is recommended. Would also recommend updating the `R-CMD check.yml` since recent versions of it take care of dependency installs using `pak`

## Reviewers

Since this is on a fork, it is difficult to test. However if the updated `R-CMD check.yml` is updated this should check install for you.
